### PR TITLE
Spell slot markers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,7 +29,6 @@ module.exports = {
       files: ['./*.js', './*.cjs', './*.mjs'],
       env: {
         node: true,
-        jquery: true,
       },
     },
   ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,8 @@ module.exports = {
 
   env: {
     browser: true,
+    es6: true,
+    jquery: true,
   },
 
   extends: ['eslint:recommended', '@typhonjs-fvtt/eslint-config-foundry.js/0.8.0', 'plugin:prettier/recommended'],
@@ -27,6 +29,7 @@ module.exports = {
       files: ['./*.js', './*.cjs', './*.mjs'],
       env: {
         node: true,
+        jquery: true,
       },
     },
   ],

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -20,6 +20,10 @@
       "expandedLimited": {
         "Label": "Use Expanded Sheet as Limited",
         "Hint": "Show the full character sheet for users who have the Limited permission for a given Actor."
+      },
+      "showSpellSlotBubbles": {
+        "Label": "Display spell slot bubbles",
+        "Hint": "Shows remaining spell slots as full or empty squares, a la DnDBeyond. You will need to close and reopen the character sheet for this setting to take effect"
       }
     }
   }

--- a/src/module/foundryvtt-compactBeyond5eSheet.mjs
+++ b/src/module/foundryvtt-compactBeyond5eSheet.mjs
@@ -13,6 +13,7 @@ export class CompactBeyond5e {
     // displayPassiveInsight: 'display-passive-ins',
     // displayPassiveInvestigation: 'display-passive-inv',
     // displayPassiveStealth: 'display-passive-ste',
+    showSpellSlotBubbles: 'show-spell-slot-bubbles',
   };
 
   /**
@@ -29,7 +30,6 @@ export class CompactBeyond5e {
   }
 
   static registerSettings() {
-    console.log('check 0');
     game.settings.register(this.MODULE_ID, this.SETTINGS.expandedLimited, {
       name: 'CB5ES.settings.expandedLimited.Label',
       default: false,
@@ -37,6 +37,15 @@ export class CompactBeyond5e {
       scope: 'world',
       config: true,
       hint: 'CB5ES.settings.expandedLimited.Hint',
+    });
+
+    game.settings.register(this.MODULE_ID, this.SETTINGS.showSpellSlotBubbles, {
+      name: 'CB5ES.settings.showSpellSlotBubbles.Label',
+      default: true,
+      type: Boolean,
+      scope: 'world',
+      config: true,
+      hint: 'CB5ES.settings.showSpellSlotBubbles.Hint',
     });
 
     // game.settings.register(this.MODULE_ID, this.SETTINGS.displayPassivePerception, {
@@ -72,6 +81,10 @@ export class CompactBeyond5e {
   // Add Spell Slot Marker
   // eslint-disable-next-line no-unused-vars
   static spellSlotMarker(app, html, data) {
+    if (!game.settings.get(this.MODULE_ID, this.SETTINGS.showSpellSlotBubbles)) {
+      return;
+    }
+
     let actor = app.actor;
     // let items = data.actor.items;
     let options = ['pact', 'spell1', 'spell2', 'spell3', 'spell4', 'spell5', 'spell6', 'spell7', 'spell8', 'spell9'];
@@ -122,7 +135,6 @@ export class CompactBeyond5e {
       const index = [...ev.currentTarget.parentElement.children].indexOf(ev.currentTarget);
       const slots = $(ev.currentTarget).parents('.spell-level-slots');
       const spellLevel = slots.find('.spell-max').data('level');
-      // debug(`tidy5e-sheet | spellSlotMarker | spellLevel: ${spellLevel}, index: ${index}`);
       if (spellLevel) {
         let path = `data.spells.${spellLevel}.value`;
         if (ev.currentTarget.classList.contains('empty')) {
@@ -159,7 +171,6 @@ export class CompactBeyond5e {
    * Registers hooks and sheets
    */
   static init() {
-    console.log('checkinit');
     Handlebars.registerHelper('cb5es-isEmpty', foundry.utils.isEmpty);
 
     Actors.registerSheet('dnd5e', CompactBeyond5eSheet, {

--- a/src/styles/foundryvtt-compactBeyond5eSheet.scss
+++ b/src/styles/foundryvtt-compactBeyond5eSheet.scss
@@ -7,6 +7,7 @@
   --accent-gray: var(--color-text-light-heading);
   --groove-gray: var(--color-border-light-highlight);
   --highlight: #44191a; // same as dnd5e
+  --light-highlight: #9e6e6f;
   --light-gray: var(--color-border-light-primary);
   --tertiary-text: var(--color-text-dark-inactive);
   --spellbook-active: #d200ff1a;

--- a/src/styles/spellbook.scss
+++ b/src/styles/spellbook.scss
@@ -43,21 +43,21 @@
       display: block;
       width: 15px;
       height: 15px;
-      // cursor: pointer;
+      cursor: pointer;
       background-color: var(--highlight);
       border: 1px solid var(--color-border-dark-5);
-      // &:hover,
-      // &.change {
-      //   background-color: var(--t5e-warning-accent);
-      // }
+      &:hover,
+      &.change {
+        background-color: var(--light-highlight);
+      }
 
       &.empty {
         background-color: transparent;
 
-        // &:hover,
-        // &.change {
-        //   background-color: var(--t5e-prepared);
-        // }
+        &:hover,
+        &.change {
+          background-color: var(--light-highlight);
+        }
       }
     }
   }

--- a/src/styles/spellbook.scss
+++ b/src/styles/spellbook.scss
@@ -33,4 +33,32 @@
       background-color: var(--spellbook-always-active);
     }
   }
+  .spellSlotMarker {
+    display: flex;
+    flex: initial;
+    gap: 2px;
+    align-items: center;
+    .dot {
+      position: relative;
+      display: block;
+      width: 15px;
+      height: 15px;
+      // cursor: pointer;
+      background-color: var(--highlight);
+      border: 1px solid var(--color-border-dark-5);
+      // &:hover,
+      // &.change {
+      //   background-color: var(--t5e-warning-accent);
+      // }
+
+      &.empty {
+        background-color: transparent;
+
+        // &:hover,
+        // &.change {
+        //   background-color: var(--t5e-prepared);
+        // }
+      }
+    }
+  }
 }

--- a/src/templates/parts/actor-spellbook.hbs
+++ b/src/templates/parts/actor-spellbook.hbs
@@ -41,7 +41,7 @@
 <ol class="items-list inventory-list">
   {{#each spellbook as |section|}}
   <li class="items-header spellbook-header flexrow">
-    <div class="item-name flexrow">
+    <div class="item-name flexrow spell-level-slots">
       <h3>{{section.label}}</h3>
       <div class="spell-slots">
         {{#if section.usesSlots}}


### PR DESCRIPTION
As requested in issue #9 this pull adds a bubble-like display showing unused spell slots, like DnDBeyond and Tidy 5e Sheet. The bubbles are clickable to add or remove spell slots, and you can turn them off in settings.

![image](https://github.com/eastcw/foundryvtt-compactBeyond5eSheet/assets/25549143/0ddf0642-c5c0-44b4-9322-5c54fcd01c02)
