### PR TITLE
General improvements

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -21,6 +21,10 @@
         "Label": "Use Expanded Sheet as Limited",
         "Hint": "Show the full character sheet for users who have the Limited permission for a given Actor."
       },
+      "showFullCurrencyNames": {
+        "Label": "Show full currency names",
+        "Hint": "Show the full currency names (Gold, Silver, Platinum) instead of the abbreviated names (GP, SP, PP)"
+      },
       "showSpellSlotBubbles": {
         "Label": "Display spell slot bubbles",
         "Hint": "Shows remaining spell slots as full or empty squares, a la DnDBeyond. You will need to close and reopen the character sheet for this setting to take effect"

--- a/src/module.json
+++ b/src/module.json
@@ -22,7 +22,7 @@
   "manifest": "https://github.com/eastcw/foundryvtt-compactBeyond5eSheet/releases/latest/download/module.json",
   "readme": "https://github.com/eastcw/foundryvtt-compactBeyond5eSheet/blob/master/README.md",
   "url": "https://github.com/eastcw/foundryvtt-compactBeyond5eSheet/",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "compatibility": {
     "minimum": "10",
     "verified": "11.307"
@@ -45,7 +45,7 @@
         "type": "system",
         "compatibility": {
           "minimum": "2.2.0",
-          "verified": "2.2.2"
+          "verified": "2.3.0"
         }
       }
     ],

--- a/src/module/foundryvtt-compactBeyond5eSheet.mjs
+++ b/src/module/foundryvtt-compactBeyond5eSheet.mjs
@@ -14,6 +14,7 @@ export class CompactBeyond5e {
     // displayPassiveInvestigation: 'display-passive-inv',
     // displayPassiveStealth: 'display-passive-ste',
     showSpellSlotBubbles: 'show-spell-slot-bubbles',
+    showFullCurrencyNames: 'show-full-currency-names',
   };
 
   /**
@@ -48,6 +49,15 @@ export class CompactBeyond5e {
       hint: 'CB5ES.settings.showSpellSlotBubbles.Hint',
     });
 
+    game.settings.register(this.MODULE_ID, this.SETTINGS.showFullCurrencyNames, {
+      name: 'CB5ES.settings.showFullCurrencyNames.Label',
+      default: false,
+      type: Boolean,
+      scope: 'world',
+      config: true,
+      hint: 'CB5ES.settings.showFullCurrencyNames.Hint',
+    });
+
     // game.settings.register(this.MODULE_ID, this.SETTINGS.displayPassivePerception, {
     //   name: 'CB5ES.settings.displayPassives.prc.Label',
     //   default: false,
@@ -76,6 +86,22 @@ export class CompactBeyond5e {
     //   scope: 'world',
     //   config: true,
     // });
+  }
+
+  // Add currency abbreviations to actor
+  // eslint-disable-next-line no-unused-vars
+  static addCurrencyAbbreviations(app, html, data) {
+    let currencies = CONFIG.DND5E.currencies;
+    this.log(true, currencies);
+    for (let i in currencies) {
+      let label = document.getElementsByClassName(`currency-abbreviation ${i}`)[0];
+      if (game.settings.get(this.MODULE_ID, this.SETTINGS.showFullCurrencyNames)) {
+        label.innerText = currencies[i].label;
+      } else {
+        label.innerText = currencies[i].abbreviation;
+      }
+      this.log(true, currencies[i].abbreviation);
+    }
   }
 
   // Add Spell Slot Marker
@@ -195,6 +221,7 @@ export class CompactBeyond5e {
 
     Hooks.on('renderCompactBeyond5eSheet', (app, html, data) => {
       this.spellSlotMarker(app, html, data);
+      this.addCurrencyAbbreviations(app, html, data);
     });
   }
 }

--- a/src/module/foundryvtt-compactBeyond5eSheet.mjs
+++ b/src/module/foundryvtt-compactBeyond5eSheet.mjs
@@ -89,10 +89,8 @@ export class CompactBeyond5e {
   }
 
   // Add currency abbreviations to actor
-  // eslint-disable-next-line no-unused-vars
-  static addCurrencyAbbreviations(app, html, data) {
+  static addCurrencyAbbreviations() {
     let currencies = CONFIG.DND5E.currencies;
-    this.log(true, currencies);
     for (let i in currencies) {
       let label = document.getElementsByClassName(`currency-abbreviation ${i}`)[0];
       if (game.settings.get(this.MODULE_ID, this.SETTINGS.showFullCurrencyNames)) {
@@ -100,7 +98,6 @@ export class CompactBeyond5e {
       } else {
         label.innerText = currencies[i].abbreviation;
       }
-      this.log(true, currencies[i].abbreviation);
     }
   }
 
@@ -221,7 +218,7 @@ export class CompactBeyond5e {
 
     Hooks.on('renderCompactBeyond5eSheet', (app, html, data) => {
       this.spellSlotMarker(app, html, data);
-      this.addCurrencyAbbreviations(app, html, data);
+      this.addCurrencyAbbreviations();
     });
   }
 }

--- a/src/styles/foundryvtt-compactBeyond5eSheet.scss
+++ b/src/styles/foundryvtt-compactBeyond5eSheet.scss
@@ -91,6 +91,11 @@
     }
   }
 
+  .items-header.flexrow,
+  .item.flexrow {
+    margin-right: 1em;
+  }
+
   /* these lists work better as wrapping flex lists so that gap can take effect */
   .item-properties,
   .traits-list {

--- a/src/styles/foundryvtt-compactBeyond5eSheet.scss
+++ b/src/styles/foundryvtt-compactBeyond5eSheet.scss
@@ -27,7 +27,7 @@
 
   .window-content {
     box-sizing: border-box;
-    color: var(--color);
+    // color: var(--color);
 
     padding: calc(#{$space} / 2);
 
@@ -144,22 +144,22 @@
   }
 
   /* More Overrides for Whetstone Support */
-  .proficient .proficiency-toggle,
-  .traits i.fas,
-  .inventory-list .item-controls .item-toggle.active,
-  .inventory-list .item .item-name {
-    color: var(--color);
-  }
+  // .proficient .proficiency-toggle,
+  // .traits i.fas,
+  // .inventory-list .item-controls .item-toggle.active,
+  // .inventory-list .item .item-name {
+  //   color: var(--color);
+  // }
 
-  .proficiency-toggle {
-    color: var(--accent-text);
-  }
+  // .proficiency-toggle {
+  //   color: var(--accent-text);
+  // }
 
-  .inventory-list .item-controls a,
-  span.sep,
-  .traits .inactive {
-    color: var(--tertiary-text);
-  }
+  // .inventory-list .item-controls a,
+  // span.sep,
+  // .traits .inactive {
+  //   color: var(--tertiary-text);
+  // }
 
   /* Scrollbars */
 

--- a/src/styles/foundryvtt-compactBeyond5eSheet.scss
+++ b/src/styles/foundryvtt-compactBeyond5eSheet.scss
@@ -91,11 +91,6 @@
     }
   }
 
-  .items-header.flexrow,
-  .item.flexrow {
-    margin-right: 1em;
-  }
-
   /* these lists work better as wrapping flex lists so that gap can take effect */
   .item-properties,
   .traits-list {
@@ -129,10 +124,19 @@
   /* complicated flex layout to allow tab areas to be scrollable */
   /* instrumental: https://stackoverflow.com/questions/52487743/prevent-flex-item-from-exceeding-parent-height-and-make-scroll-bar-work */
 
-  .sheet-sidebar {
+  .sheet-sidebar,
+  .items-header.flexrow,
+  .item.flexrow {
     overflow: auto;
     scrollbar-width: thin;
     padding-right: $scrollbar-width;
+  }
+
+  @-moz-document url-prefix() {
+    .items-header.flexrow,
+    .item.flexrow {
+      padding-right: 0.75em;
+    }
   }
 
   .sheet-tab-area {

--- a/src/styles/foundryvtt-compactBeyond5eSheet.scss
+++ b/src/styles/foundryvtt-compactBeyond5eSheet.scss
@@ -91,11 +91,6 @@
     }
   }
 
-  .items-header.flexrow,
-  .item.flexrow {
-    margin-right: 1em;
-  }
-
   /* these lists work better as wrapping flex lists so that gap can take effect */
   .item-properties,
   .traits-list {
@@ -133,6 +128,14 @@
     overflow: auto;
     scrollbar-width: thin;
     padding-right: $scrollbar-width;
+  }
+
+  @-moz-document url-prefix() {
+    .items-header.flexrow,
+    .item.flexrow,
+    .sheet-sidebar {
+      padding-right: 1em;
+    }
   }
 
   .sheet-tab-area {

--- a/src/styles/inventory.scss
+++ b/src/styles/inventory.scss
@@ -17,6 +17,10 @@
   }
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
 .currency {
   display: flex;
   flex-direction: column;

--- a/src/templates/parts/actor-inventory.hbs
+++ b/src/templates/parts/actor-inventory.hbs
@@ -21,7 +21,7 @@
     <div class="currency-inputs">
       {{#each system.currency as |v k|}}
       <label class="denomination {{k}}">
-        {{#if @root/systemFeatures.currencyLabels}}{{ lookup @root/labels.currencies k }}{{else}}{{k}}{{/if}}
+        <span class="currency-abbreviation {{k}}"></span>
         <div class="dynamic-input">
           <input type="text" name="system.currency.{{k}}" value="{{v}}" data-dtype="Number" />
           <span class="hidden">{{ v }}</span>

--- a/src/templates/parts/actor-inventory.hbs
+++ b/src/templates/parts/actor-inventory.hbs
@@ -3,7 +3,11 @@
   {{#unless isNPC}}
   <div class="encumberance">
     {{#with system.attributes.encumbrance}}
-    <h3><strong>{{localize "CB5ES.WeightCarried"}}:</strong> {{ value }} {{ @root.weightUnit }}</h3>
+    <h3><strong>{{localize "CB5ES.WeightCarried"}}:</strong>
+      <span class="no-wrap">
+        {{ value }} {{ @root.weightUnit }}
+      </span>
+    </h3>
     <span class="{{#if (gt value max)}}encumbered{{/if}}">
       {{localize "DND5E.Max"}}: {{ max }} {{ @root.weightUnit }}
     </span>

--- a/src/templates/parts/sheet-header.hbs
+++ b/src/templates/parts/sheet-header.hbs
@@ -64,7 +64,7 @@
   <section>
     <div class="flexrow health-armor">
 
-      <div class="ac attributable" data-property="attributes.ac">
+      <div class="ac" data-attribution="attributes.ac" data-tooltip-direction="RIGHT">
         <div class="ac-symbol">
           {{> (concat moduleFilePath "assets/armor-class.hbs")}}
         </div>


### PR DESCRIPTION
- Changed the scrollbar behaviour slightly in Firefox, since it doesn't use the same scrollbar styling rules as other browsers
- Fixed interactions with DnD Dark Mode (fixes #14 )
- Added a setting to show full currency names (Gold, silver, etc) instead of the abbreviated names (GP, SP, etc). This also changes how the names of the currencies are read, so they should update properly if edited by other scripts (fixes #13 ). I'm not yet quite happy with the layout of the sheet when the long names are used, since it causes the weight display to overflow when the sheet is narrow.